### PR TITLE
Download build artifacts to the correct folder

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: build-artifacts
+          path: dist/
 
       - name: Publish to GitHub Release
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8


### PR DESCRIPTION
Previously, we get this error:

> 🤔 Pattern 'dist/*' does not match any files.

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/3b08d9b7-094f-4e79-9b9c-64ee2ea0e48c">


https://github.com/WATonomous/github-actions-tracing/actions/runs/11205850086/job/31145840267

This PR should fix it.