### PR TITLE
Add a check for generating perfetto_trace_pb2.py

### DIFF
--- a/scripts/generate-perfetto-trace-proto.sh
+++ b/scripts/generate-perfetto-trace-proto.sh
@@ -8,7 +8,8 @@ check_proto() {
     echo "cf1ec0ad32d6772a2bf852e17195e1616062c2afa2320a2eb3f8af7f7956d7e3 tmp/perfetto_trace.proto" | sha256sum --check $@
 }
 
-if ! check_proto --status 2>/dev/null; then
+# Generate python bindings from perfetto_trace.proto
+if ! check_proto --status 2>/dev/null || [ ! -f vendor/generated/perfetto_trace_pb2.py ]; then
     echo "Downloading and generating python bindings from perfetto_trace.proto"
     # Download the proto file
     wget --no-verbose https://raw.githubusercontent.com/google/perfetto/993ddf5c3382546f1bf7437bb71a087e530e2900/protos/perfetto/trace/perfetto_trace.proto -O tmp/perfetto_trace.proto


### PR DESCRIPTION
Previously, we only checked whether tmp/perfetto_trace.proto existed to trigger generating python bindings. This PR makes it so that we also check whether the generated file exists.