### PR TITLE
Remove auto-generated vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,4 +185,3 @@ pyrightconfig.json
 
 /tmp
 /vendor/generated/*
-!/vendor/generated/.gitkeep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,3 @@ pre_build = "./scripts/generate-perfetto-trace-proto.sh"
 [tool.pdm.build]
 # Docs: https://backend.pdm-project.org/build_config/#include-or-exclude-files
 includes = ["src", "vendor"]
-excludes = ["**/.gitkeep"]

--- a/scripts/generate-perfetto-trace-proto.sh
+++ b/scripts/generate-perfetto-trace-proto.sh
@@ -3,6 +3,7 @@
 set -o errexit -o nounset -o pipefail
 
 mkdir -p tmp
+mkdir -p vendor/generated
 
 check_proto() {
     echo "cf1ec0ad32d6772a2bf852e17195e1616062c2afa2320a2eb3f8af7f7956d7e3 tmp/perfetto_trace.proto" | sha256sum --check $@


### PR DESCRIPTION
The `vendor/generated` directory is dynamically generated. There's no need to keep it in git.