### PR TITLE
Introduce macOS dev compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,19 @@ jobs:
       fail-fast: false # Continue running jobs even if one fails
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.17
+      - name: Set up Docker (macOS)
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: |
+          brew install colima
+          colima start
 
       - name: Set up PDM
         uses: pdm-project/setup-pdm@568ddd69406b30de1774ec0044b73ae06e716aa4 # v4.1
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.17
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
           brew install colima
-          colima start
+          brew services start colima
 
       - name: Set up PDM
         uses: pdm-project/setup-pdm@568ddd69406b30de1774ec0044b73ae06e716aa4 # v4.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
       fail-fast: false # Continue running jobs even if one fails
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Docker (macOS)
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
-          brew install colima
+          brew install colima docker
           brew services start colima
 
       - name: Set up PDM

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
           brew install colima docker
-          brew services start colima
+          colima start
 
       - name: Set up PDM
         uses: pdm-project/setup-pdm@568ddd69406b30de1774ec0044b73ae06e716aa4 # v4.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false # Continue running jobs even if one fails
 
     steps:

--- a/scripts/generate-perfetto-trace-proto.sh
+++ b/scripts/generate-perfetto-trace-proto.sh
@@ -6,7 +6,7 @@ mkdir -p tmp
 mkdir -p vendor/generated
 
 check_proto() {
-    echo "cf1ec0ad32d6772a2bf852e17195e1616062c2afa2320a2eb3f8af7f7956d7e3 tmp/perfetto_trace.proto" | sha256sum --check $@
+    echo "cf1ec0ad32d6772a2bf852e17195e1616062c2afa2320a2eb3f8af7f7956d7e3  tmp/perfetto_trace.proto" | shasum -a 256 --check $@
 }
 
 # Generate python bindings from perfetto_trace.proto


### PR DESCRIPTION
Some commands weren't compatible with macOS. This PR introduces macOS compatibility.

In CI, colima doesn't seem to start with macos-latest, and only works with macos-13. This may be because macos-13 is intel-based and macos-latest is M1-based: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Here's the full logs for installing and starting colima on macos-latest:

```
Warning: Treating docker as a formula. For the cask, use homebrew/cask/docker or specify the `--cask` flag. To silence this message, use the `--formula` flag.
==> Downloading https://ghcr.io/v2/homebrew/core/colima/manifests/0.8.0
==> Fetching dependencies for colima: lima
==> Downloading https://ghcr.io/v2/homebrew/core/lima/manifests/1.0.2
==> Fetching lima
==> Downloading https://ghcr.io/v2/homebrew/core/lima/blobs/sha25[6](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:7):6cbe64ea673896c549a302833a[7](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:8)54d33c1a1d777cfc8df9e9f634ce5bac6bca2
==> Fetching colima
==> Downloading https://ghcr.io/v2/homebrew/core/colima/blobs/sha256:7ba14eef41c[8](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:9)0f216f62b34d006c946ec7807cce09ec3e8e3a4b83ada92c16a7
==> Downloading https://ghcr.io/v2/homebrew/core/docker/manifests/27.4.0
==> Fetching dependencies for docker: docker-completion
==> Downloading https://ghcr.io/v2/homebrew/core/docker-completion/manifests/27.4.0
==> Fetching docker-completion
==> Downloading https://ghcr.io/v2/homebrew/core/docker-completion/blobs/sha256:d817eab656d53b497b902f6b50e229f0adaae39a70651d2894bce3d7c38bf25a
==> Fetching docker
==> Downloading https://ghcr.io/v2/homebrew/core/docker/blobs/sha256:de0bb1445d1d89281d0ca2bfe06fc5adea7f6869bffbd4e6fa06be1fa4b93c6d
==> Installing dependencies for colima: lima
==> Installing colima dependency: lima
==> Downloading https://ghcr.io/v2/homebrew/core/lima/manifests/1.0.2
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/af154faf06ab15e50482cc6[9](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:10)92b5d8af26ee95e22a166bef6c17957d01570cc5--lima-1.0.2.bottle_manifest.json
==> Pouring lima--1.0.2.arm64_sonoma.bottle.tar.gz
🍺  /opt/homebrew/Cellar/lima/1.0.2: [10](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:11)6 files, 204.3MB
==> Installing colima
==> Pouring colima--0.8.0.arm64_sonoma.bottle.tar.gz
==> Caveats
Bash completion has been installed to:
  /opt/homebrew/etc/bash_completion.d

To start colima now and restart at login:
  brew services start colima
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/colima/bin/colima start -f
==> Summary
🍺  /opt/homebrew/Cellar/colima/0.8.0: [11](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:12) files, 5.7MB
==> Installing dependencies for docker: docker-completion
==> Installing docker dependency: docker-completion
==> Downloading https://ghcr.io/v2/homebrew/core/docker-completion/manifests/27.4.0
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/26e5f39b5af50dd753cb523006304f6d3f9016[12](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:13)5b05f9d6b5028a5354616d6d--docker-completion-27.4.0.bottle_manifest.json
==> Pouring docker-completion--27.4.0.all.bottle.tar.gz
🍺  /opt/homebrew/Cellar/docker-completion/27.4.0: 10 files, 342.2KB
==> Installing docker
==> Pouring docker--27.4.0.arm64_sonoma.bottle.tar.gz
🍺  /opt/homebrew/Cellar/docker/27.4.0: 14 files, 25.8MB
==> Caveats
==> colima
Bash completion has been installed to:
  /opt/homebrew/etc/bash_completion.d

To start colima now and restart at login:
  brew services start colima
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/colima/bin/colima start -f
time="2024-12-30T00:04:12Z" level=info msg="starting colima"
time="2024-12-30T00:04:12Z" level=info msg="runtime: docker"
time="2024-12-30T00:04:14Z" level=info msg="creating and starting ..." context=vm
time="2024-12-30T00:04:14Z" level=info msg="downloading disk image ..." context=vm

#                                                                          2.4%
####                                                                       5.7%
######                                                                     8.5%
#######                                                                   11.0%
#########                                                                 [13](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:14).5%
###########                                                               [15](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:16).7%
############                                                              [18](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:19).1%
##############                                                            20.3%
################                                                          22.5%
#################                                                         24.6%
###################                                                       27.0%
#####################                                                     29.3%
######################                                                    31.5%
########################                                                  33.5%
#########################                                                 35.9%
###########################                                               37.9%
############################                                              40.2%
##############################                                            42.7%
################################                                          45.0%
#################################                                         47.2%
###################################                                       49.4%
#####################################                                     51.9%
######################################                                    54.0%
########################################                                  56.4%
##########################################                                58.8%
############################################                              61.3%
#############################################                             63.7%
###############################################                           66.2%
#################################################                         68.5%
###################################################                       71.0%
####################################################                      73.5%
######################################################                    76.0%
########################################################                  78.2%
#########################################################                 80.4%
###########################################################               82.3%
############################################################              84.5%
##############################################################            86.7%
################################################################          88.9%
#################################################################         91.0%
##################################################################        92.8%
####################################################################      95.0%
#####################################################################     97.2%
#######################################################################   99.6%
######################################################################## 100.0%
time="2024-12-30T00:04:21Z" level=info msg="Terminal is not available, proceeding without opening an editor"
time="2024-12-30T00:04:22Z" level=info msg="Starting the instance \"colima\" with VM driver \"vz\""
time="2024-12-30T00:04:22Z" level=warning msg="vmType vz: ignoring networks[0]: [Metric]"
time="2024-12-30T00:04:22Z" level=info msg="Attempting to download the image" arch=aarch64 digest= location=/Users/runner/Library/Caches/colima/caches/c3056771d27045a9b7b665f5ddbbac4e311078337847c505226bd184c8[19](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:20)1d0c
time="2024-12-30T00:04:22Z" level=info msg="Downloaded the image from \"/Users/runner/Library/Caches/colima/caches/c3056771d27045a9b7b665f5ddbbac4e311078337847c505226bd184c8191d0c\""
time="[20](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:21)24-12-30T00:04:22Z" level=info msg="Converting \"/Users/runner/.colima/_lima/colima/basedisk\" (qcow2) to a raw disk \"/Users/runner/.colima/_lima/colima/diffdisk\""
time="2024-12-30T00:04:26Z" level=info msg="Expanding to 100GiB"
time="2024-12-30T00:04:27Z" level=info msg="[hostagent] hostagent socket created at /Users/runner/.colima/_lima/colima/ha.sock"
time="20[24](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:25)-12-30T00:04:27Z" level=info msg="[hostagent] Starting VZ (hint: to watch the boot progress, see \"/Users/runner/.colima/_lima/colima/serial*.log\")"
time="2024-12-30T00:04:[27](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:28)Z" level=fatal msg="exiting, status={Running:false Degraded:false Exiting:true Errors:[] SSHLocalPort:0} (hint: see \"/Users/runner/.colima/_lima/colima/ha.stderr.log\")"
time="2024-12-[30](https://github.com/WATonomous/github-actions-tracing/actions/runs/12539759539/job/34966223852#step:2:31)T00:04:27Z" level=fatal msg="error starting vm: error at 'creating and starting': exit status 1"
Error: Process completed with exit code 1.
```